### PR TITLE
Disable setting .md file syntax to mdx

### DIFF
--- a/ftdetect/mdx.vim
+++ b/ftdetect/mdx.vim
@@ -5,4 +5,3 @@
 "
 
 autocmd BufNewFile,BufRead *.mdx set filetype=markdown.mdx
-autocmd BufNewFile,BufRead *.md set filetype=markdown.mdx


### PR DESCRIPTION
Not every .md file is mdx. This unblocks using this plugin unmodified in vim-polyglot